### PR TITLE
Add Activity API tests

### DIFF
--- a/ActivityTests.cs
+++ b/ActivityTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using RestApiNUnitTests.ApiClients;
+using RestApiNUnitTests.Models;
+
+namespace RestApiNUnitTests
+{
+    [TestFixture]
+    public class ActivityTests
+    {
+        private HttpClient _httpClient;
+        private ActivityApiClient _activityApiClient;
+
+        [SetUp]
+        public void Setup()
+        {
+            _httpClient = new HttpClient();
+            _httpClient.BaseAddress = new Uri("https://fakerestapi.azurewebsites.net/");
+            _activityApiClient = new ActivityApiClient(_httpClient);
+        }
+
+        [Test]
+        public async Task GetAllActivities_ReturnsActivities()
+        {
+            var activities = await _activityApiClient.GetAllActivitiesAsync();
+            Assert.IsNotNull(activities);
+            Assert.IsTrue(activities.Length > 0);
+        }
+
+        [Test]
+        public async Task GetActivityById_ReturnsCorrectActivity()
+        {
+            int id = 1;
+            var activity = await _activityApiClient.GetActivityByIdAsync(id);
+            Assert.IsNotNull(activity);
+            Assert.AreEqual(id, activity.Id);
+        }
+
+        [Test]
+        public async Task CreateActivity_ReturnsCreatedActivity()
+        {
+            var newActivity = new Activity
+            {
+                Title = "Test Activity",
+                DueDate = DateTime.Now.AddDays(7),
+                Completed = false
+            };
+
+            var createdActivity = await _activityApiClient.CreateActivityAsync(newActivity);
+            Assert.IsNotNull(createdActivity);
+            Assert.AreEqual(newActivity.Title, createdActivity.Title);
+            Assert.AreEqual(newActivity.DueDate.Date, createdActivity.DueDate.Date);
+            Assert.AreEqual(newActivity.Completed, createdActivity.Completed);
+        }
+
+        [Test]
+        public async Task UpdateActivity_ReturnsUpdatedActivity()
+        {
+            int id = 1;
+            var updatedActivity = new Activity
+            {
+                Id = id,
+                Title = "Updated Test Activity",
+                DueDate = DateTime.Now.AddDays(14),
+                Completed = true
+            };
+
+            var result = await _activityApiClient.UpdateActivityAsync(id, updatedActivity);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(updatedActivity.Id, result.Id);
+            Assert.AreEqual(updatedActivity.Title, result.Title);
+            Assert.AreEqual(updatedActivity.DueDate.Date, result.DueDate.Date);
+            Assert.AreEqual(updatedActivity.Completed, result.Completed);
+        }
+
+        [Test]
+        public async Task DeleteActivity_DoesNotThrowException()
+        {
+            int id = 1;
+            Assert.DoesNotThrowAsync(() => _activityApiClient.DeleteActivityAsync(id));
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _httpClient.Dispose();
+        }
+    }
+}

--- a/ApiClients/ActivityApiClient.cs
+++ b/ApiClients/ActivityApiClient.cs
@@ -1,0 +1,56 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using RestApiNUnitTests.Models;
+
+namespace RestApiNUnitTests.ApiClients
+{
+    public class ActivityApiClient : ApiClient
+    {
+        public ActivityApiClient(HttpClient client) : base(client)
+        {
+        }
+
+        public async Task<Activity[]> GetAllActivitiesAsync()
+        {
+            var response = await Client.GetAsync("/api/v1/Activities");
+            response.EnsureSuccessStatusCode();
+            var content = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<Activity[]>(content);
+        }
+
+        public async Task<Activity> GetActivityByIdAsync(int id)
+        {
+            var response = await Client.GetAsync($"/api/v1/Activities/{id}");
+            response.EnsureSuccessStatusCode();
+            var content = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<Activity>(content);
+        }
+
+        public async Task<Activity> CreateActivityAsync(Activity activity)
+        {
+            var json = JsonConvert.SerializeObject(activity);
+            var content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
+            var response = await Client.PostAsync("/api/v1/Activities", content);
+            response.EnsureSuccessStatusCode();
+            var responseContent = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<Activity>(responseContent);
+        }
+
+        public async Task<Activity> UpdateActivityAsync(int id, Activity activity)
+        {
+            var json = JsonConvert.SerializeObject(activity);
+            var content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
+            var response = await Client.PutAsync($"/api/v1/Activities/{id}", content);
+            response.EnsureSuccessStatusCode();
+            var responseContent = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<Activity>(responseContent);
+        }
+
+        public async Task DeleteActivityAsync(int id)
+        {
+            var response = await Client.DeleteAsync($"/api/v1/Activities/{id}");
+            response.EnsureSuccessStatusCode();
+        }
+    }
+}

--- a/Models/Activity.cs
+++ b/Models/Activity.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace RestApiNUnitTests.Models
+{
+    public class Activity
+    {
+        public int Id { get; set; }
+        public string Title { get; set; }
+        public DateTime DueDate { get; set; }
+        public bool Completed { get; set; }
+    }
+}


### PR DESCRIPTION
This pull request adds tests for the Activities endpoint. It includes:
1. A new ActivityApiClient class for interacting with the Activities API
2. An Activity model class
3. ActivityTests class with unit tests for CRUD operations on Activities

These changes follow a similar style to the existing BookTests in the repository.